### PR TITLE
Change slash command routes to immediately return 200 response to route

### DIFF
--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.8.2
+python-3.8.3

--- a/src/host.py
+++ b/src/host.py
@@ -22,20 +22,20 @@ class Host:
     command_prefix = '/'
     intro_text = 'This iiiiiis trebekbot!'
     help_text = '''
-    Use '''+command_prefix+''' to prefix commands.
-    '''+command_prefix+'''help: bring up this help list
-    '''+command_prefix+'''hello: say hello to trebekbot
-    '''+command_prefix+'''ask: trebekbot will ask you a question
-    '''+command_prefix+'''next: get a new question from the previous category
-    '''+command_prefix+'''skip: skip current question
-    '''+command_prefix+'''whatis: use this to provide an answer to the question
-    '''+command_prefix+'''myscore: find out what your current score is
-    '''+command_prefix+'''mywins: find out your all-time win count
-    '''+command_prefix+'''topten: find out who the top ten scorers are
-    '''+command_prefix+'''wager: put in your wager for daily doubles
-    '''+command_prefix+'''nope: pass a daily double if you don't know it
-    '''+command_prefix+'''changelog: show latest changelog notes
-    '''+command_prefix+'''uptime: show start time of this trebekbot
+    Use ''' + command_prefix + ''' to prefix commands.
+    ''' + command_prefix + '''help: bring up this help list
+    ''' + command_prefix + '''hello: say hello to trebekbot
+    ''' + command_prefix + '''ask: trebekbot will ask you a question
+    ''' + command_prefix + '''next: get a new question from the previous category
+    ''' + command_prefix + '''skip: skip current question
+    ''' + command_prefix + '''whatis: use this to provide an answer to the question
+    ''' + command_prefix + '''myscore: find out what your current score is
+    ''' + command_prefix + '''mywins: find out your all-time win count
+    ''' + command_prefix + '''topten: find out who the top ten scorers are
+    ''' + command_prefix + '''wager: put in your wager for daily doubles
+    ''' + command_prefix + '''nope: pass a daily double if you don't know it
+    ''' + command_prefix + '''changelog: show latest changelog notes
+    ''' + command_prefix + '''uptime: show start time of this trebekbot
     '''
 
     def __init__(self, slack_token, user_db):
@@ -49,7 +49,7 @@ class Host:
         self.current_champion_name, self.current_champion_score = None, None
         try:
             self.current_champion_name, self.current_champion_score = \
-            self.user_db.get_champion(self.user_db.connection)
+                self.user_db.get_champion(self.user_db.connection)
         except TypeError:
             pass
         # create leaderboard
@@ -63,8 +63,8 @@ class Host:
             user_db.increment_win(user_db.connection, self.current_champion_name)
             self.say(self.channel, 'Let\'s welcome back last night\'s returning champion, \
             :crown: @' + self.current_champion_name + '!')
-            self.say(self.channel, 'With a total cash winnings of '+ \
-            '$' + str(self.current_champion_score) + '!')
+            self.say(self.channel, 'With a total cash winnings of ' +
+                     '$' + str(self.current_champion_score) + '!')
         # show yesterday's leaderboard
         self.say(self.channel, 'Here\'s yesterday\'s top scores:')
         self.say(self.channel, self.top_ten())
@@ -111,9 +111,9 @@ class Host:
         :param: user_id
         """
         if self.current_champion_name == user_name:
-            return ':crown: <@'+user_id+'>'
+            return ':crown: <@' + user_id + '>'
         else:
-            return '<@'+user_id+'>'
+            return '<@' + user_id + '>'
 
     def create_daily_double_address(self, user_name, user_id):
         """
@@ -124,8 +124,8 @@ class Host:
         user_address = self.create_user_address(user_name, user_id)
         user_score = self.my_score(user_name, user_id)
         return 'It\'s a DAILY DOUBLE!\n' + user_address + \
-        ' [$' + user_score + '] ' + \
-        'Please enter a wager with the /wager command'
+               ' [$' + user_score + '] ' + \
+               'Please enter a wager with the /wager command'
 
     def get_bot_id(self, bot_name):
         """
@@ -156,7 +156,7 @@ class Host:
                 if version_number_line and not found_latest:
                     found_latest = True
                     latest_changelog += line
-                elif version_number_line and found_latest :
+                elif version_number_line and found_latest:
                     return latest_changelog
                 elif found_latest:
                     latest_changelog += line
@@ -167,6 +167,7 @@ class Host:
     :param: user_name:
     :param: user_id:
     '''
+
     def get_wager(self, wager, user_name, user_id):
         user_score = self.user_db.get_score(self.user_db.connection, user_name)
         user_address = self.create_user_address(user_name, user_id)
@@ -183,6 +184,7 @@ class Host:
     adjusts wager according to jeopardy rules, this is separate from get_wager
     to bypass slack api for unit testing
     '''
+
     @staticmethod
     def calc_wager(wager, user_score: int):
         # we want this to return a None if we get a TypeError, that way
@@ -218,31 +220,31 @@ class Host:
         # if answer is close but not wrong
         if answer_check == 'close':
             return user_address + ' ' + \
-            Judge.check_closeness(user_answer, correct_answer)
+                   Judge.check_closeness(user_answer, correct_answer)
         # right answer
         elif answer_check == True:
             # award points to user
             if question.daily_double:
                 self.user_db.update_score(
-                self.user_db.connection, user_name, wager
+                    self.user_db.connection, user_name, wager
                 )
             else:
                 self.user_db.update_score(
-                self.user_db.connection, user_name, question.value
+                    self.user_db.connection, user_name, question.value
                 )
             return user_address + \
-            ' :white_check_mark: That is correct. The answer is ' \
-            +correct_answer
+                   ' :white_check_mark: That is correct. The answer is ' \
+                   + correct_answer
         # wrong answer
         elif answer_check == False:
             # take away points from user
             if question.daily_double and wager:
                 self.user_db.update_score(
-                self.user_db.connection, user_name, -wager
+                    self.user_db.connection, user_name, -wager
                 )
             else:
                 self.user_db.update_score(
-                self.user_db.connection, user_name, -question.value
+                    self.user_db.connection, user_name, -question.value
                 )
             return user_address + ' :x: Sorry, that is incorrect.'
 
@@ -253,6 +255,7 @@ class Host:
     :param: user_name:
     :param: user_id:
     '''
+
     def my_score(self, user_name, user_id):
         user_score = str(
             self.user_db.get_score(self.user_db.connection, user_name)
@@ -285,6 +288,6 @@ class Host:
     def my_wins(self, user_name, user_id):
         user_address = self.create_user_address(user_name, user_id)
         wins = str(
-        self.user_db.get_user_wins(self.user_db.connection, user_name)
+            self.user_db.get_user_wins(self.user_db.connection, user_name)
         )
         return user_address + ' wins: ' + wins

--- a/src/main.py
+++ b/src/main.py
@@ -147,8 +147,8 @@ live_question = Question(Question.get_random_question(), Timer(time_limit, reset
 # Routes
 
 # say hi!
-@keep_alive_response
 @app.route('/hello', methods=['POST'])
+@keep_alive_response
 def hello():
     # TEST
     # post(request.base_url, json=jsonify({'text': ''}))

--- a/src/main.py
+++ b/src/main.py
@@ -173,7 +173,7 @@ def hello():
     if request.form['channel_name'] == channel:
         Thread(target=rev_hello_handler).start()
         with app.app_context():
-            return post(os.environ['WEBHOOK'], json={'text': ''})
+            return jsonify({'text': ''})
     else:
         return handle_payload(wrong_channel_payload)
 

--- a/src/main.py
+++ b/src/main.py
@@ -165,7 +165,10 @@ def hello():
     # TEST
     if request.form['channel_name'] == channel:
         Thread(target=hello_handler)
-        return post(request.base_url, json=jsonify({'text': 'TEST'}))
+        payload = jsonify({'text': 'TEST'})
+        payload.status_code = 200
+        post(request.base_url, json=payload)
+        return pass
     else:
         return handle_payload(wrong_channel_payload)
 

--- a/src/main.py
+++ b/src/main.py
@@ -6,6 +6,7 @@ bot_name = 'trebekbot'
 import os
 import urllib.parse as urlparse
 from threading import Timer, Thread
+from json import dumps
 # trebekbot classes
 from src.db import db
 from src.host import Host
@@ -15,6 +16,7 @@ from src.question import Question
 from flask import Flask, jsonify, request
 from requests import post
 from slack import WebClient
+
 
 
 app = Flask(__name__)
@@ -151,7 +153,7 @@ live_question = Question(Question.get_random_question(), Timer(time_limit, reset
 #@keep_alive_response
 def hello():
     # TEST
-    post(request.base_url, json=jsonify({'text': ''}))
+    post(request.base_url, json=dumps({'text': ''}))
     if request.form['channel_name'] == channel:
         user_name = request.form['user_name']
         user_id = request.form['user_id']

--- a/src/main.py
+++ b/src/main.py
@@ -12,7 +12,7 @@ from src.host import Host
 from src.judge import Judge
 from src.question import Question
 # third-party libs
-from flask import Flask, jsonify, request, make_response
+from flask import Flask, jsonify, request, Response
 from requests import post
 from slack import WebClient
 
@@ -176,7 +176,7 @@ def hello():
         response_url = request.form['response_url']
         Thread(target=rev_hello_handler, args=[response_url, user_name, user_id]).start()
         with app.app_context():
-            return make_response(200)
+            return Response(status=200)
     else:
         return handle_payload(wrong_channel_payload)
 

--- a/src/main.py
+++ b/src/main.py
@@ -245,7 +245,7 @@ def whatis():
         payload['text'] = 'Judges?'
     Thread(target=handle_payload,
            args=[payload, request.form['response_url'], request.form['channel_name']]).start()
-    return jsonify({'text': answer})
+    return jsonify({'text': answer, 'response_type': 'in_channel'})
 
 # get a new question from the last question's category
 @app.route('/next', methods=['POST'])

--- a/src/main.py
+++ b/src/main.py
@@ -142,7 +142,7 @@ def hello():
         }
         Thread(target=handle_payload, args=[payload, request.form['response_url']]).start()
         with app.app_context():
-            return Response(status=200)
+            return "200"
     else:
         return handle_payload(wrong_channel_payload, request.form['response_url'])
 

--- a/src/main.py
+++ b/src/main.py
@@ -175,7 +175,8 @@ def hello():
         response_url = request.form['response_url']
         Thread(target=rev_hello_handler, args=[response_url, user_name, user_id]).start()
         with app.app_context():
-            return jsonify({'text': ' '})
+            import json
+            return json.dumps({'text': ' '})
     else:
         return handle_payload(wrong_channel_payload)
 

--- a/src/main.py
+++ b/src/main.py
@@ -170,7 +170,7 @@ def rev_hello_handler():
 def hello():
     # TEST
     if request.form['channel_name'] == channel:
-        payload = {'text': ''}
+        payload = {'text': ' '}
         payload = jsonify(payload)
         payload.status_code = 200
         Thread(target=rev_hello_handler).start()

--- a/src/main.py
+++ b/src/main.py
@@ -80,6 +80,7 @@ def hello_handler():
     }
     payload = jsonify(payload)
     payload.status_code = 200
+    sleep(1)
     return payload
 
 
@@ -168,7 +169,6 @@ def hello():
         Thread(target=hello_handler)
         payload = jsonify({'text': 'TEST'})
         payload.status_code = 200
-        sleep(1)
         post(request.base_url, json=payload)
         return None
     else:

--- a/src/main.py
+++ b/src/main.py
@@ -130,30 +130,21 @@ live_question = Question(Question.get_random_question(), Timer(time_limit, reset
 
 # Routes
 
-def channel_check(route_func):
-    def route_wrapper():
-        if request.form['channel_name'] == channel:
-            route_func()
-        else:
-            return handle_payload(wrong_channel_payload)
-    return route_wrapper
-
 # say hi!
-@channel_check
 @app.route('/hello', methods=['POST'])
 def hello():
-    # if request.form['channel_name'] == channel:
-    user_name = request.form['user_name']
-    user_id = request.form['user_id']
-    payload = {
-        'text': 'Hello ' + host.create_user_address(user_name, user_id),
-        'response_type': 'in_channel'
-    }
-    Thread(target=handle_payload, args=[payload, request.form['response_url']]).start()
-    with app.app_context():
-        return Response(status=200)
-    # else:
-    #     return handle_payload(wrong_channel_payload)
+    if request.form['channel_name'] == channel:
+        user_name = request.form['user_name']
+        user_id = request.form['user_id']
+        payload = {
+            'text': 'Hello ' + host.create_user_address(user_name, user_id),
+            'response_type': 'in_channel'
+        }
+        Thread(target=handle_payload, args=[payload, request.form['response_url']]).start()
+        with app.app_context():
+            return Response(status=200)
+    else:
+        return handle_payload(wrong_channel_payload)
 
 
 host = Host(slack_token, user_db)

--- a/src/main.py
+++ b/src/main.py
@@ -152,12 +152,24 @@ def hello_handler():
     print('test')
     post(os.environ['WEBHOOK'], json=payload)
 
+
+def rev_hello_handler():
+    user_name = request.form['user_name']
+    user_id = request.form['user_id']
+    payload = {
+        'text': 'Hello ' + host.create_user_address(user_name, user_id),
+        'response_type': 'in_channel'
+    }
+    payload = jsonify(payload)
+    payload.status_code = 200
+    return payload
+
 # say hi!
 @app.route('/hello', methods=['POST'])
 def hello():
     # TEST
     if request.form['channel_name'] == channel:
-        Thread(target=hello_handler()).start()
+        Thread(target=hello_handler).start()
         user_name = request.form['user_name']
         user_id = request.form['user_id']
         payload = {

--- a/src/main.py
+++ b/src/main.py
@@ -154,10 +154,8 @@ def hello_handler():
         # post(base_url, json=payload)
 
 
-def rev_hello_handler(response_url):
+def rev_hello_handler(response_url, user_name, user_id):
     with app.test_request_context():
-        user_name = request.form['user_name']
-        user_id = request.form['user_id']
         payload = {
             'text': 'Hello ' + host.create_user_address(user_name, user_id),
             'response_type': 'in_channel'
@@ -171,7 +169,10 @@ def rev_hello_handler(response_url):
 def hello():
     # TEST
     if request.form['channel_name'] == channel:
-        Thread(target=rev_hello_handler, args=[request.form['response_url']]).start()
+        user_name = request.form['user_name']
+        user_id = request.form['user_id']
+        response_url = request.form['response_url']
+        Thread(target=rev_hello_handler, args=[response_url, user_name, user_id]).start()
         with app.app_context():
             return jsonify({'text': ' '})
     else:

--- a/src/main.py
+++ b/src/main.py
@@ -245,7 +245,7 @@ def whatis():
         payload['text'] = 'Judges?'
     Thread(target=handle_payload,
            args=[payload, request.form['response_url'], request.form['channel_name']]).start()
-    return Response(status=200)
+    return jsonify({'text': answer})
 
 # get a new question from the last question's category
 @app.route('/next', methods=['POST'])

--- a/src/main.py
+++ b/src/main.py
@@ -146,19 +146,15 @@ live_question = Question(Question.get_random_question(), Timer(time_limit, reset
 
 
 # Routes
-def hello_handler():
-    payload = jsonify({'text': 'TEST'})
-    print('DEBUG')
-    payload.status_code = 200
-    post(os.environ['WEBHOOK'], json=payload)
-    return None
 
 # say hi!
 @app.route('/hello', methods=['POST'])
 def hello():
     # TEST
     if request.form['channel_name'] == channel:
-        Thread(target=hello_handler)
+        payload = jsonify({'text': 'TEST'})
+        payload.status_code = 200
+        post(os.environ['WEBHOOK'], json=payload)
         user_name = request.form['user_name']
         user_id = request.form['user_id']
         payload = {

--- a/src/main.py
+++ b/src/main.py
@@ -146,13 +146,12 @@ live_question = Question(Question.get_random_question(), Timer(time_limit, reset
 
 
 # Routes
-def hello_handler(base_url):
+def hello_handler():
     with app.app_context():
-        payload = {'text': 'TEST'}
-        print(base_url)
+        payload = {'text': ''}
         # payload.status_code = 200
-        #post(os.environ['WEBHOOK'], json=payload)
-        post(base_url, json=payload)
+        post(os.environ['WEBHOOK'], json=payload)
+        #post(base_url, json=payload)
 
 
 def rev_hello_handler():
@@ -171,7 +170,7 @@ def rev_hello_handler():
 def hello():
     # TEST
     if request.form['channel_name'] == channel:
-        Thread(target=hello_handler, args=[request.base_url]).start()
+        Thread(target=hello_handler).start()
         user_name = request.form['user_name']
         user_id = request.form['user_id']
         payload = {

--- a/src/main.py
+++ b/src/main.py
@@ -147,10 +147,11 @@ live_question = Question(Question.get_random_question(), Timer(time_limit, reset
 
 # Routes
 def hello_handler():
-    payload = jsonify({'text': 'TEST'})
-    payload.status_code = 200
-    print('test')
-    post(os.environ['WEBHOOK'], json=payload)
+    with app.app_context():
+        payload = jsonify({'text': 'TEST'})
+        payload.status_code = 200
+        print('test')
+        post(os.environ['WEBHOOK'], json=payload)
 
 
 def rev_hello_handler():

--- a/src/main.py
+++ b/src/main.py
@@ -149,6 +149,7 @@ live_question = Question(Question.get_random_question(), Timer(time_limit, reset
 def hello_handler(base_url):
     with app.app_context():
         payload = {'text': 'TEST'}
+        print(base_url)
         # payload.status_code = 200
         #post(os.environ['WEBHOOK'], json=payload)
         post(base_url, json=payload)

--- a/src/main.py
+++ b/src/main.py
@@ -167,7 +167,7 @@ def hello():
         Thread(target=hello_handler)
         payload = jsonify({'text': 'TEST'})
         payload.status_code = 200
-        post(request.form['response_url'], json=payload)
+        post(os.environ['WEBHOOK'], json=payload)
         return None
     else:
         return handle_payload(wrong_channel_payload)

--- a/src/main.py
+++ b/src/main.py
@@ -142,7 +142,7 @@ def hello():
         }
         Thread(target=handle_payload, args=[payload, request.form['response_url']]).start()
         with app.app_context():
-            return "200"
+            return Response(status=200)
     else:
         return handle_payload(wrong_channel_payload, request.form['response_url'])
 

--- a/src/main.py
+++ b/src/main.py
@@ -156,7 +156,10 @@ def hello_handler():
 def hello():
     # TEST
     if request.form['channel_name'] == channel:
-        Thread(target=hello_handler)
+        payload = jsonify({'text': 'TEST', 'response_type': 'in_channel'})
+        payload.status_code = 200
+        print(request.base_url)
+        post(request.base_url, json=payload)
         user_name = request.form['user_name']
         user_id = request.form['user_id']
         payload = {

--- a/src/main.py
+++ b/src/main.py
@@ -144,20 +144,13 @@ def reset_timer():
 # load this in the background to speed up response time
 live_question = Question(Question.get_random_question(), Timer(time_limit, reset_timer))
 
+
 # Routes
-
-
 def hello_handler():
-    user_name = request.form['user_name']
-    user_id = request.form['user_id']
-    payload = {
-        'text': 'Hello ' + host.create_user_address(user_name, user_id),
-        'response_type': 'in_channel'
-    }
-    payload = jsonify(payload)
+    payload = jsonify({'text': 'TEST'})
     payload.status_code = 200
-    return payload
-
+    post(os.environ['WEBHOOK'], json=payload)
+    return None
 
 # say hi!
 @app.route('/hello', methods=['POST'])
@@ -165,10 +158,15 @@ def hello():
     # TEST
     if request.form['channel_name'] == channel:
         Thread(target=hello_handler)
-        payload = jsonify({'text': 'TEST'})
+        user_name = request.form['user_name']
+        user_id = request.form['user_id']
+        payload = {
+            'text': 'Hello ' + host.create_user_address(user_name, user_id),
+            'response_type': 'in_channel'
+        }
+        payload = jsonify(payload)
         payload.status_code = 200
-        post(os.environ['WEBHOOK'], json=payload)
-        return None
+        return payload
     else:
         return handle_payload(wrong_channel_payload)
 

--- a/src/main.py
+++ b/src/main.py
@@ -79,7 +79,7 @@ def hello_handler():
     }
     payload = jsonify(payload)
     payload.status_code = 200
-    post(request.base_url, payload)
+    return payload
 
 
 def keep_alive_response(func):

--- a/src/main.py
+++ b/src/main.py
@@ -139,8 +139,8 @@ def channel_check(route_func):
     return route_wrapper
 
 # say hi!
-@app.route('/hello', methods=['POST'])
 @channel_check
+@app.route('/hello', methods=['POST'])
 def hello():
     # if request.form['channel_name'] == channel:
     user_name = request.form['user_name']

--- a/src/main.py
+++ b/src/main.py
@@ -122,8 +122,8 @@ live_question = Question(Question.get_random_question(), Timer(time_limit, reset
 #     return payload
 
 
-def handle_payload(payload, response_url):
-    if request.form['channel_name'] == channel:
+def handle_payload(payload, response_url, request_channel):
+    if request_channel == channel:
         with app.test_request_context():
             return post(response_url, dumps(payload))
     else:
@@ -140,7 +140,7 @@ def hello():
         'text': 'Hello ' + host.create_user_address(user_name, user_id),
         'response_type': 'in_channel'
     }
-    Thread(target=handle_payload, args=[payload, request.form['response_url']]).start()
+    Thread(target=handle_payload, args=[payload, request.form['response_url'], request.form['channel_name']]).start()
     with app.app_context():
         return Response(status=200)
 

--- a/src/main.py
+++ b/src/main.py
@@ -148,10 +148,10 @@ live_question = Question(Question.get_random_question(), Timer(time_limit, reset
 
 # say hi!
 @app.route('/hello', methods=['POST'])
-@keep_alive_response
+#@keep_alive_response
 def hello():
     # TEST
-    # post(request.base_url, json=jsonify({'text': ''}))
+    post(request.base_url, json=jsonify({'text': ''}))
     if request.form['channel_name'] == channel:
         user_name = request.form['user_name']
         user_id = request.form['user_id']

--- a/src/main.py
+++ b/src/main.py
@@ -172,7 +172,7 @@ def hello():
     if request.form['channel_name'] == channel:
         Thread(target=rev_hello_handler).start()
         with app.app_context():
-            return post(os.environ['WEBHOOK'], json=payload)
+            return post(os.environ['WEBHOOK'], json={'text': ''})
     else:
         return handle_payload(wrong_channel_payload)
 

--- a/src/main.py
+++ b/src/main.py
@@ -148,7 +148,7 @@ live_question = Question(Question.get_random_question(), Timer(time_limit, reset
 # Routes
 def hello_handler():
     with app.app_context():
-        payload = {'text': ''}
+        payload = {'text': ' '}
         # payload.status_code = 200
         post(os.environ['WEBHOOK'], json=payload)
         #post(base_url, json=payload)

--- a/src/main.py
+++ b/src/main.py
@@ -147,8 +147,9 @@ live_question = Question(Question.get_random_question(), Timer(time_limit, reset
 
 # Routes
 def hello_handler():
-    payload = jsonify({'text': 'TEST', 'response_type': 'in_channel'})
+    payload = jsonify({'text': 'TEST'})
     payload.status_code = 200
+    print('test')
     post(os.environ['WEBHOOK'], json=payload)
 
 # say hi!

--- a/src/main.py
+++ b/src/main.py
@@ -176,7 +176,7 @@ def hello():
         response_url = request.form['response_url']
         Thread(target=rev_hello_handler, args=[response_url, user_name, user_id]).start()
         with app.app_context():
-            return 200
+            return flask.make_response(200)
     else:
         return handle_payload(wrong_channel_payload)
 

--- a/src/main.py
+++ b/src/main.py
@@ -148,7 +148,7 @@ live_question = Question(Question.get_random_question(), Timer(time_limit, reset
 # Routes
 def hello_handler():
     with app.app_context():
-        payload = {'text': ' '}
+        payload = {'text': ''}
         # payload.status_code = 200
         post(os.environ['WEBHOOK'], json=payload)
         # post(base_url, json=payload)
@@ -173,7 +173,7 @@ def hello():
     if request.form['channel_name'] == channel:
         Thread(target=rev_hello_handler).start()
         with app.app_context():
-            return jsonify({'text': ''})
+            return jsonify({'text': ' '})
     else:
         return handle_payload(wrong_channel_payload)
 

--- a/src/main.py
+++ b/src/main.py
@@ -148,7 +148,7 @@ live_question = Question(Question.get_random_question(), Timer(time_limit, reset
 # Routes
 def hello_handler():
     with app.app_context():
-        payload = {'text': ' '}
+        payload = {'text': ''}
         # payload.status_code = 200
         post(os.environ['WEBHOOK'], json=payload)
         #post(base_url, json=payload)
@@ -170,15 +170,10 @@ def rev_hello_handler():
 def hello():
     # TEST
     if request.form['channel_name'] == channel:
-        Thread(target=hello_handler).start()
-        user_name = request.form['user_name']
-        user_id = request.form['user_id']
-        payload = {
-            'text': 'Hello ' + host.create_user_address(user_name, user_id),
-            'response_type': 'in_channel'
-        }
+        payload = {'text': ''}
         payload = jsonify(payload)
         payload.status_code = 200
+        Thread(target=rev_hello_handler).start()
         return payload
     else:
         return handle_payload(wrong_channel_payload)

--- a/src/main.py
+++ b/src/main.py
@@ -155,15 +155,16 @@ def hello_handler():
 
 
 def rev_hello_handler():
-    user_name = request.form['user_name']
-    user_id = request.form['user_id']
-    payload = {
-        'text': 'Hello ' + host.create_user_address(user_name, user_id),
-        'response_type': 'in_channel'
-    }
-    payload = jsonify(payload)
-    payload.status_code = 200
-    return payload
+    with app.app_context():
+        user_name = request.form['user_name']
+        user_id = request.form['user_id']
+        payload = {
+            'text': 'Hello ' + host.create_user_address(user_name, user_id),
+            'response_type': 'in_channel'
+        }
+        payload = jsonify(payload)
+        payload.status_code = 200
+        return payload
 
 # say hi!
 @app.route('/hello', methods=['POST'])

--- a/src/main.py
+++ b/src/main.py
@@ -78,6 +78,7 @@ def keep_alive_response(func):
     :return: wrapper function
     """
     def wrap_func():
+        print('decorated')
         Thread(target=send_200)
         func()
     return wrap_func

--- a/src/main.py
+++ b/src/main.py
@@ -154,7 +154,7 @@ def hello_handler():
         # post(base_url, json=payload)
 
 
-def rev_hello_handler():
+def rev_hello_handler(response_url):
     with app.test_request_context():
         user_name = request.form['user_name']
         user_id = request.form['user_id']
@@ -163,15 +163,15 @@ def rev_hello_handler():
             'response_type': 'in_channel'
         }
         payload = jsonify(payload)
-        payload.status_code = 200
-        return payload
+        # payload.status_code = 200
+        post(response_url, payload)
 
 # say hi!
 @app.route('/hello', methods=['POST'])
 def hello():
     # TEST
     if request.form['channel_name'] == channel:
-        Thread(target=rev_hello_handler).start()
+        Thread(target=rev_hello_handler, args=[request.form['response_url']]).start()
         with app.app_context():
             return jsonify({'text': ' '})
     else:

--- a/src/main.py
+++ b/src/main.py
@@ -168,7 +168,7 @@ def hello():
         payload = jsonify({'text': 'TEST'})
         payload.status_code = 200
         post(request.base_url, json=payload)
-        return pass
+        return None
     else:
         return handle_payload(wrong_channel_payload)
 

--- a/src/main.py
+++ b/src/main.py
@@ -156,10 +156,7 @@ def hello_handler():
 def hello():
     # TEST
     if request.form['channel_name'] == channel:
-        payload = jsonify({'text': 'TEST', 'response_type': 'in_channel'})
-        payload.status_code = 200
-        print(request.base_url)
-        post(request.base_url, json=payload)
+        Thread(target=hello_handler()).start()
         user_name = request.form['user_name']
         user_id = request.form['user_id']
         payload = {

--- a/src/main.py
+++ b/src/main.py
@@ -124,8 +124,7 @@ live_question = Question(Question.get_random_question(), Timer(time_limit, reset
 
 def handle_payload(payload, response_url, request_channel):
     if request_channel == channel:
-        with app.test_request_context():
-            return post(response_url, dumps(payload))
+        return post(response_url, dumps(payload))
     else:
         return post(response_url, dumps(wrong_channel_payload))
 

--- a/src/main.py
+++ b/src/main.py
@@ -148,6 +148,7 @@ live_question = Question(Question.get_random_question(), Timer(time_limit, reset
 # Routes
 def hello_handler():
     payload = jsonify({'text': 'TEST'})
+    print('DEBUG')
     payload.status_code = 200
     post(os.environ['WEBHOOK'], json=payload)
     return None

--- a/src/main.py
+++ b/src/main.py
@@ -151,7 +151,7 @@ def hello_handler():
         payload = {'text': ''}
         # payload.status_code = 200
         post(os.environ['WEBHOOK'], json=payload)
-        #post(base_url, json=payload)
+        # post(base_url, json=payload)
 
 
 def rev_hello_handler():
@@ -170,11 +170,8 @@ def rev_hello_handler():
 def hello():
     # TEST
     if request.form['channel_name'] == channel:
-        payload = {'text': ' '}
-        payload = jsonify(payload)
-        payload.status_code = 200
         Thread(target=rev_hello_handler).start()
-        return payload
+        return post(os.environ['WEBHOOK'], json=payload)
     else:
         return handle_payload(wrong_channel_payload)
 

--- a/src/main.py
+++ b/src/main.py
@@ -6,6 +6,7 @@ bot_name = 'trebekbot'
 import os
 import urllib.parse as urlparse
 from threading import Timer, Thread
+from json import dumps
 # trebekbot classes
 from src.db import db
 from src.host import Host
@@ -70,7 +71,6 @@ categorized_questions = []
 
 def handle_payload(payload, response_url):
     with app.test_request_context():
-        from json import dumps
         payload = dumps(payload)
         post(response_url, payload)
 
@@ -144,7 +144,7 @@ def hello():
         with app.app_context():
             return Response(status=200)
     else:
-        return handle_payload(wrong_channel_payload)
+        return handle_payload(wrong_channel_payload, request.form['response_url'])
 
 
 host = Host(slack_token, user_db)

--- a/src/main.py
+++ b/src/main.py
@@ -176,7 +176,8 @@ def hello():
         response_url = request.form['response_url']
         Thread(target=rev_hello_handler, args=[response_url, user_name, user_id]).start()
         with app.app_context():
-            return jsonify({'text': ' '})
+            from json import dumps
+            return dumps({200, {'ContentType': 'application/json'}})
     else:
         return handle_payload(wrong_channel_payload)
 

--- a/src/main.py
+++ b/src/main.py
@@ -160,7 +160,8 @@ def rev_hello_handler(response_url, user_name, user_id):
             'text': 'Hello ' + host.create_user_address(user_name, user_id),
             'response_type': 'in_channel'
         }
-        payload = jsonify(payload)
+        from json import dumps
+        payload = dumps(payload)
         # payload.status_code = 200
         print(response_url)
         post(response_url, payload)
@@ -175,8 +176,7 @@ def hello():
         response_url = request.form['response_url']
         Thread(target=rev_hello_handler, args=[response_url, user_name, user_id]).start()
         with app.app_context():
-            import json
-            return json.dumps({'text': ' '})
+            return jsonify({'text': ' '})
     else:
         return handle_payload(wrong_channel_payload)
 

--- a/src/main.py
+++ b/src/main.py
@@ -147,7 +147,7 @@ live_question = Question(Question.get_random_question(), Timer(time_limit, reset
 
 # Routes
 def hello_handler():
-    payload = jsonify({'text': 'TEST'})
+    payload = jsonify({'text': 'TEST', 'response_type': 'in_channel'})
     payload.status_code = 200
     post(os.environ['WEBHOOK'], json=payload)
 
@@ -157,8 +157,6 @@ def hello():
     # TEST
     if request.form['channel_name'] == channel:
         Thread(target=hello_handler)
-        from time import sleep
-        sleep(1)
         user_name = request.form['user_name']
         user_id = request.form['user_id']
         payload = {

--- a/src/main.py
+++ b/src/main.py
@@ -146,13 +146,12 @@ live_question = Question(Question.get_random_question(), Timer(time_limit, reset
 
 
 # Routes
-def hello_handler():
+def hello_handler(base_url):
     with app.app_context():
         payload = {'text': 'TEST'}
         # payload.status_code = 200
-        print('test')
         #post(os.environ['WEBHOOK'], json=payload)
-        post(request.base_url, json=payload)
+        post(base_url, json=payload)
 
 
 def rev_hello_handler():
@@ -171,7 +170,7 @@ def rev_hello_handler():
 def hello():
     # TEST
     if request.form['channel_name'] == channel:
-        Thread(target=hello_handler).start()
+        Thread(target=hello_handler, args=[request.base_url]).start()
         user_name = request.form['user_name']
         user_id = request.form['user_id']
         payload = {

--- a/src/main.py
+++ b/src/main.py
@@ -12,7 +12,7 @@ from src.host import Host
 from src.judge import Judge
 from src.question import Question
 # third-party libs
-from flask import Flask, jsonify, request
+from flask import Flask, jsonify, request, make_response
 from requests import post
 from slack import WebClient
 
@@ -176,7 +176,7 @@ def hello():
         response_url = request.form['response_url']
         Thread(target=rev_hello_handler, args=[response_url, user_name, user_id]).start()
         with app.app_context():
-            return flask.make_response(200)
+            return make_response(200)
     else:
         return handle_payload(wrong_channel_payload)
 

--- a/src/main.py
+++ b/src/main.py
@@ -168,7 +168,7 @@ def hello():
         Thread(target=hello_handler)
         payload = jsonify({'text': 'TEST'})
         payload.status_code = 200
-        sleep(3)
+        sleep(1)
         post(request.base_url, json=payload)
         return None
     else:

--- a/src/main.py
+++ b/src/main.py
@@ -151,7 +151,8 @@ def hello_handler():
         payload = {'text': 'TEST'}
         # payload.status_code = 200
         print('test')
-        post(os.environ['WEBHOOK'], json=payload)
+        #post(os.environ['WEBHOOK'], json=payload)
+        post(request.base_url, json=payload)
 
 
 def rev_hello_handler():

--- a/src/main.py
+++ b/src/main.py
@@ -6,7 +6,6 @@ bot_name = 'trebekbot'
 import os
 import urllib.parse as urlparse
 from threading import Timer, Thread
-from time import sleep
 # trebekbot classes
 from src.db import db
 from src.host import Host
@@ -69,19 +68,6 @@ def send_200():
     payload.status_code = 200
     print('posted')
     post(request.base_url, json=payload)
-
-
-def hello_handler():
-    user_name = request.form['user_name']
-    user_id = request.form['user_id']
-    payload = {
-        'text': 'Hello ' + host.create_user_address(user_name, user_id),
-        'response_type': 'in_channel'
-    }
-    payload = jsonify(payload)
-    payload.status_code = 200
-    sleep(1)
-    return payload
 
 
 def keep_alive_response(func):
@@ -160,16 +146,28 @@ live_question = Question(Question.get_random_question(), Timer(time_limit, reset
 
 # Routes
 
+
+def hello_handler():
+    user_name = request.form['user_name']
+    user_id = request.form['user_id']
+    payload = {
+        'text': 'Hello ' + host.create_user_address(user_name, user_id),
+        'response_type': 'in_channel'
+    }
+    payload = jsonify(payload)
+    payload.status_code = 200
+    return payload
+
+
 # say hi!
 @app.route('/hello', methods=['POST'])
-#@keep_alive_response
 def hello():
     # TEST
     if request.form['channel_name'] == channel:
         Thread(target=hello_handler)
         payload = jsonify({'text': 'TEST'})
         payload.status_code = 200
-        post(request.base_url, json=payload)
+        post(request.form['request_url'], json=payload)
         return None
     else:
         return handle_payload(wrong_channel_payload)

--- a/src/main.py
+++ b/src/main.py
@@ -148,10 +148,10 @@ live_question = Question(Question.get_random_question(), Timer(time_limit, reset
 # Routes
 def hello_handler():
     with app.app_context():
-        payload = jsonify({'text': 'TEST'})
+        payload = {'text': 'TEST'}
         payload.status_code = 200
         print('test')
-        post(os.environ['WEBHOOK'], json=payload)
+        post(os.environ['WEBHOOK'], data=payload)
 
 
 def rev_hello_handler():

--- a/src/main.py
+++ b/src/main.py
@@ -148,7 +148,7 @@ live_question = Question(Question.get_random_question(), Timer(time_limit, reset
 # Routes
 def hello_handler():
     with app.app_context():
-        payload = {'text': ''}
+        payload = {'text': ' '}
         # payload.status_code = 200
         post(os.environ['WEBHOOK'], json=payload)
         # post(base_url, json=payload)

--- a/src/main.py
+++ b/src/main.py
@@ -171,7 +171,8 @@ def hello():
     # TEST
     if request.form['channel_name'] == channel:
         Thread(target=rev_hello_handler).start()
-        return post(os.environ['WEBHOOK'], json=payload)
+        with app.app_context():
+            return post(os.environ['WEBHOOK'], json=payload)
     else:
         return handle_payload(wrong_channel_payload)
 

--- a/src/main.py
+++ b/src/main.py
@@ -167,7 +167,7 @@ def hello():
         Thread(target=hello_handler)
         payload = jsonify({'text': 'TEST'})
         payload.status_code = 200
-        post(request.form['request_url'], json=payload)
+        post(request.form['response_url'], json=payload)
         return None
     else:
         return handle_payload(wrong_channel_payload)

--- a/src/main.py
+++ b/src/main.py
@@ -162,6 +162,7 @@ def rev_hello_handler(response_url, user_name, user_id):
         }
         payload = jsonify(payload)
         # payload.status_code = 200
+        print(response_url)
         post(response_url, payload)
 
 # say hi!

--- a/src/main.py
+++ b/src/main.py
@@ -141,8 +141,8 @@ def hello():
         'response_type': 'in_channel'
     }
     Thread(target=handle_payload, args=[payload, request.form['response_url'], request.form['channel_name']]).start()
-    with app.app_context():
-        return Response(status=200)
+    #with app.app_context():
+    return Response(status=200)
 
 
 host = Host(slack_token, user_db)

--- a/src/main.py
+++ b/src/main.py
@@ -155,7 +155,7 @@ def hello_handler():
 
 
 def rev_hello_handler():
-    with app.app_context():
+    with app.test_request_context():
         user_name = request.form['user_name']
         user_id = request.form['user_id']
         payload = {

--- a/src/main.py
+++ b/src/main.py
@@ -6,6 +6,7 @@ bot_name = 'trebekbot'
 import os
 import urllib.parse as urlparse
 from threading import Timer, Thread
+from time import sleep
 # trebekbot classes
 from src.db import db
 from src.host import Host
@@ -167,6 +168,7 @@ def hello():
         Thread(target=hello_handler)
         payload = jsonify({'text': 'TEST'})
         payload.status_code = 200
+        sleep(3)
         post(request.base_url, json=payload)
         return None
     else:

--- a/src/main.py
+++ b/src/main.py
@@ -176,8 +176,7 @@ def hello():
         response_url = request.form['response_url']
         Thread(target=rev_hello_handler, args=[response_url, user_name, user_id]).start()
         with app.app_context():
-            from json import dumps
-            return dumps({200, {'ContentType': 'application/json'}})
+            return 200
     else:
         return handle_payload(wrong_channel_payload)
 

--- a/src/main.py
+++ b/src/main.py
@@ -146,15 +146,19 @@ live_question = Question(Question.get_random_question(), Timer(time_limit, reset
 
 
 # Routes
+def hello_handler():
+    payload = jsonify({'text': 'TEST'})
+    payload.status_code = 200
+    post(os.environ['WEBHOOK'], json=payload)
 
 # say hi!
 @app.route('/hello', methods=['POST'])
 def hello():
     # TEST
     if request.form['channel_name'] == channel:
-        payload = jsonify({'text': 'TEST'})
-        payload.status_code = 200
-        post(os.environ['WEBHOOK'], json=payload)
+        Thread(target=hello_handler)
+        from time import sleep
+        sleep(1)
         user_name = request.form['user_name']
         user_id = request.form['user_id']
         payload = {

--- a/src/main.py
+++ b/src/main.py
@@ -149,9 +149,9 @@ live_question = Question(Question.get_random_question(), Timer(time_limit, reset
 def hello_handler():
     with app.app_context():
         payload = {'text': 'TEST'}
-        payload.status_code = 200
+        # payload.status_code = 200
         print('test')
-        post(os.environ['WEBHOOK'], data=payload)
+        post(os.environ['WEBHOOK'], json=payload)
 
 
 def rev_hello_handler():


### PR DESCRIPTION
This PR changes all slash commands to return a 200 response and do any subsequent work in a separate thread.  This should ensure that we don't reach a timeout for slash commands. 

NOTE: despite the branch name, this does not involve the use of a decorator.